### PR TITLE
Fix Coveralls CI build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,4 +41,4 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           parallel-finished: true
-          carryforward: "2.6,2.7,3.0,3.1,3.2"
+          carryforward: '2.6,2.7,3.0,3.1,3.2'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@master
         with:
-          github-token: ${{ secrets.github_token }}
           flag-name: ${{ matrix.ruby }}
           parallel: true
 
@@ -41,5 +40,5 @@ jobs:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@master
         with:
-          github-token: ${{ secrets.github_token }}
           parallel-finished: true
+          carryforward: "2.6,2.7,3.0,3.1,3.2"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,6 +29,9 @@ jobs:
         run: bundle exec rake
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@master
+        env:
+          # We're concatenating the run ID with the run attempt so that each run has a different ID for Coveralls.
+          COVERALLS_SERVICE_JOB_ID: '${{ github.run_id }} ${{ github.run_attempt }}'
         with:
           flag-name: ${{ matrix.ruby }}
           parallel: true
@@ -39,6 +42,9 @@ jobs:
     steps:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@master
+        env:
+          # We're concatenating the run ID with the run attempt so that each run has a different ID for Coveralls.
+          COVERALLS_SERVICE_JOB_ID: '${{ github.run_id }} ${{ github.run_attempt }}'
         with:
           parallel-finished: true
           carryforward: '2.6,2.7,3.0,3.1,3.2'


### PR DESCRIPTION
Coveralls identifiers job IDs based on the GitHub Actions run ID. Unfortunately, this means that retries will always fail since Coveralls denies pushing coverage information to a build that's already closed. This PR attempts to fix that issue by combining the attempt with the run ID, which should provide a unique identifier for the job that we can safely use in the presence of retries.

For reference, the set of environment variables we can use in a job are listed [here](https://github.com/coverallsapp/coverage-reporter/blob/4e78dd575102644c10e9e15e44cb136fd32645c2/doc/configuration.md#env-variables).