### PR TITLE
Update actions/checkout to v3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
           - '3.2'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Updates the action/checkout step to v3 to avoid the following deprecations:

<img width="1142" alt="Screenshot 2023-06-13 at 17 46 13" src="https://github.com/adzerk/frise/assets/143188/dec1dfcb-4388-407c-9c0c-dfe1221891c6">
