### PR TITLE
Add PR description markdown template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,12 +4,12 @@ Please also include relevant motivation and context;
 Consider describing the type of change - If it's a new feature, a bug fix, a refactor, etc.
 -->
 
-### Does this change relate to existing features and pull requests?
+### Does this change relate to existing features or pull requests?
 
 <!--
-Include links to stories that should be fixed with this change or that are related to this change.
+Include links to issues that should be fixed with this change or that are related to this change.
 If this change depends on existing pull requests, also include a link to them here.
-If this change needs a follow up, describe what still needs to be done, including links to already opened stories or pull requests.
+If this change needs a follow up, describe what still needs to be done, including links to already opened issues or pull requests.
 -->
 
 ### Does this change require an update to the documentation?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+<!--
+Please include a summary of the change;
+Please also include relevant motivation and context;
+Consider describing the type of change - If it's a new feature, a bug fix, a refactor, etc.
+-->
+
+### Does this change relate to existing features and pull requests?
+
+<!--
+Include links to stories that should be fixed with this change or that are related to this change.
+If this change depends on existing pull requests, also include a link to them here.
+If this change needs a follow up, describe what still needs to be done, including links to already opened stories or pull requests.
+-->
+
+### Does this change require an update to the documentation?
+
+<!--
+If relevant, please consider reflecting the changes you are introducing in our documentation.
+-->
+
+### How has this been tested?
+
+<!--
+Please describe the tests you ran to verify your change;
+Additionally, provide reproducible instructions;
+Finally, also list any relevant details for your test configuration.
+-->


### PR DESCRIPTION
This repo was missing a nice-looking PR description template!

### Does this change relate to existing features and pull requests?

No.

### Does this change require an update to the documentation?

No.

### How has this been tested?

By using the PR description template in this exact PR! 😄 
