### PR TITLE
Update nodejs version used in GitHub actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
           - '3.2'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
We are using github actions versions that, underlying, are using NodeJS 16 (which is mark for deprecation!).
We should bump their versions to the ones using NodeJS 20.

### Does this change require an update to the documentation?

No.

### Can this PR be safely merged to the target branch after approval?

Yes.

### How has this been tested?

Relying on CI.
